### PR TITLE
Lowered default shake threshold to make it more responsive to new users

### DIFF
--- a/schemas/org.gnome.shell.extensions.jiggle.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.jiggle.gschema.xml
@@ -7,7 +7,7 @@
             <default>0.4</default>
         </key>
         <key name="shake-threshold" type="i">
-            <default>300</default>
+            <default>160</default>
         </key>
     </schema>
 </schemalist>


### PR DESCRIPTION
First of all, as someone with retinal issues, may I first thank you for your work. One of the major drawbacks to GNOME for me is that I have to resize my cursor late in the evenings as my eyestrain would become so severe that I'd be unable to find the cursor. The large cursor accessibility mode is fine, but I find the cursor to be a little bit invasive and off-putting from a UX point of view.

This fixes that problem.

This is a little fix to change the default shake threshold from 160 to 300 - to make it a little bit more responsive to new users (as noted here https://github.com/jeffchannell/jiggle/issues/6)

Best wishes,

Keiron