### PR TITLE
update Tweener imports for Gnome 3.38

### DIFF
--- a/effects/FireworksEffect.js
+++ b/effects/FireworksEffect.js
@@ -4,7 +4,6 @@
 
 const {cairo, Gdk, GObject, St} = imports.gi;
 
-const Tweener = imports.ui.tweener;
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 

--- a/effects/ScalingEffect.js
+++ b/effects/ScalingEffect.js
@@ -2,7 +2,7 @@
 
 const {cairo, Gdk, Gio, GObject, St} = imports.gi;
 
-const Tweener = imports.ui.tweener;
+const Tweener = (function(){let i;try {i=imports.ui.tweener}catch(e){i=imports.tweener.tweener}return i})(); // Gnome 3.38 moved Tweener
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const ExtensionUtils = imports.misc.extensionUtils;

--- a/effects/SpotlightEffect.js
+++ b/effects/SpotlightEffect.js
@@ -2,7 +2,7 @@
 
 const {cairo, Gdk, GObject, St} = imports.gi;
 
-const Tweener = imports.ui.tweener;
+const Tweener = (function(){let i;try {i=imports.ui.tweener}catch(e){i=imports.tweener.tweener}return i})(); // Gnome 3.38 moved Tweener
 const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 


### PR DESCRIPTION
All effects were broken on the latest Ubuntu 20.10/Gnome 3.38.1 due to a change in where Gnome kept its libraries.

This patch gives a fallback for systems that have different include paths for Tweener.