### PR TITLE
Add Gnome 41 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Jiggle",
     "description": "Jiggle is a Gnome Shell extension that highlights the cursor position when the mouse is moved rapidly.",
     "url": "https://github.com/jeffchannell/jiggle",
-    "shell-version": [ "3.36.3", "3.38.1", "40.0" ],
-    "version": "8"
+    "shell-version": [ "3.36.3", "3.38.1", "40.0", "41.0" ],
+    "version": "9"
 }


### PR DESCRIPTION
This should fix #50

Adds support for gnome 41 in metadata. In my (extremely limited) testing the extension should work without any changes on version 41.