### PR TITLE
Update metadata to support GNOME 40.5.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Jiggle",
     "description": "Jiggle is a Gnome Shell extension that highlights the cursor position when the mouse is moved rapidly.",
     "url": "https://github.com/jeffchannell/jiggle",
-    "shell-version": [ "3.36.3", "3.38.1", "40.0", "41.0" ],
+    "shell-version": [ "3.36.3", "3.38.1", "40", "41" ],
     "version": "9"
 }


### PR DESCRIPTION
This uses just major version for GNOME 40 and beyond as suggested in
https://gjs.guide/extensions/overview/anatomy.html#shell-version

I tested on 40.5 and it works great. I think this change will
adjust the INCOMPATIBLE label on the website to show the installer
widget so people don't have to install manually.