### PR TITLE
update metadata to support shell version by major number

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Jiggle",
     "description": "Jiggle is a Gnome Shell extension that highlights the cursor position when the mouse is moved rapidly.",
     "url": "https://github.com/jeffchannell/jiggle",
-    "shell-version": [ "3.36.3", "3.38.1", "40.0", "41.0" ],
+    "shell-version": [ "3.36.3", "3.38.1", "40", "41" ],
     "version": "9"
 }


### PR DESCRIPTION
So we don't have to list any minor version added, unless some particular minor version breaks.

This enable to install in latest ubuntu (gnome 40.4.0)