### PR TITLE
skip random pointer position (0,0)

### DIFF
--- a/history.js
+++ b/history.js
@@ -60,5 +60,8 @@ function clear()
  */
 function push(x, y)
 {
+    if (x == 0 && y == 0) {
+        return;
+    }
     history.push({x: lastX = x, y: lastY = y, t: new Date().getTime()});
 }

--- a/history.js
+++ b/history.js
@@ -63,5 +63,8 @@ function push(x, y)
     if (x == 0 && y == 0) {
         return;
     }
+    if (x < 0 || y < 0) {
+        return;
+    }
     history.push({x: lastX = x, y: lastY = y, t: new Date().getTime()});
 }


### PR DESCRIPTION
sometimes I got a big cursor when some clicks after app switching, do some log and found the value max exceeds 700 but normally 200, and it happens when I got random pointer position (0,0); not sure why but just simple skipping (0,0) seems work.