### PR TITLE
No more tweener

### DIFF
--- a/effects/Effects.js
+++ b/effects/Effects.js
@@ -4,3 +4,22 @@ var CURSOR_SCALING = 0;
 var FIREWORKS = 1;
 var SPOTLIGHT = 2;
 var TRAIL = 3;
+
+// formulas from https://easings.net
+const _transitions = {
+    easeInQuad: (x) => x * x,
+    easeOutQuad: (x) => 1 - (1 - x) * (1 - x),
+};
+
+const _animate = (to, from, framecount, transition) => {
+    let frames = [];
+    
+    for (let distance = from - to, idx = 0; idx <= framecount; idx++) {
+        frames.push(to + (distance * transition(idx / framecount)));
+    }
+
+    return frames;
+};
+
+var Transitions = _transitions;
+var animate = _animate;

--- a/effects/Effects.js
+++ b/effects/Effects.js
@@ -5,13 +5,19 @@ var FIREWORKS = 1;
 var SPOTLIGHT = 2;
 var TRAIL = 3;
 
+var AnimationDirections = {
+    GROW: 1,
+    PAUSE: 0,
+    SHRINK: -1,
+};
+
 // formulas from https://easings.net
-const _transitions = {
+var Transitions = {
     easeInQuad: (x) => x * x,
     easeOutQuad: (x) => 1 - (1 - x) * (1 - x),
 };
 
-const _animate = (to, from, framecount, transition) => {
+var animate = (to, from, framecount, transition) => {
     let frames = [];
     
     for (let distance = from - to, idx = 0; idx <= framecount; idx++) {
@@ -20,6 +26,3 @@ const _animate = (to, from, framecount, transition) => {
 
     return frames;
 };
-
-var Transitions = _transitions;
-var animate = _animate;

--- a/extension.js
+++ b/extension.js
@@ -33,28 +33,23 @@ let settingsID;
  * Stop the listeners and clean up any leftover assets.
  */
 function disable() {
-    try {
-        JLog.logInfo('Jiggle disable');
-        // reset to defaults
-        jiggling = false;
-        JHistory.clear();
-        // remove our pointer listener
-        if (pointerListener) {
-            JLog.logDebug('Clearing pointer listener');
-            PointerWatcher._removeWatch(pointerListener);
-        }
-        // stop the interval
-        intervals.map(i => Mainloop.source_remove(i));
-        intervals = [];
-        // disconnect from the settings
-        if (settingsID) {
-            JLog.logDebug('Disconnecting from gsettings');
-            settings.disconnect(settingsID);
-            settings = null;
-        }
-    } catch (e) {
-        JLog.logErr(e);
-        throw e;
+    JLog.logInfo('Jiggle disable');
+    // reset to defaults
+    jiggling = false;
+    JHistory.clear();
+    // remove our pointer listener
+    if (pointerListener) {
+        JLog.logDebug('Clearing pointer listener');
+        PointerWatcher._removeWatch(pointerListener);
+    }
+    // stop the interval
+    intervals.map(i => Mainloop.source_remove(i));
+    intervals = [];
+    // disconnect from the settings
+    if (settingsID) {
+        JLog.logDebug('Disconnecting from gsettings');
+        settings.disconnect(settingsID);
+        settings = null;
     }
 }
 
@@ -100,7 +95,8 @@ function enable() {
             return true;
         }));
     } catch (e) {
-        JLog.logErr(e);
+        // ensure we clean up any leftovers if there's a problem!
+        disable();
         throw e;
     }
 }
@@ -110,7 +106,6 @@ function enable() {
  */
 function init() {
     JLog.logInfo('Jiggle init');
-    disable(); // always ensure we start from a disabled state
 }
 
 function update() {

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Jiggle",
     "description": "Jiggle is a Gnome Shell extension that highlights the cursor position when the mouse is moved rapidly.",
     "url": "https://github.com/jeffchannell/jiggle",
-    "shell-version": [ "3.36.3", "3.38.1", "40", "41", "42" ],
+    "shell-version": [ "40", "41", "42" ],
     "version": "9"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -19,8 +19,6 @@ if (JConstants.IS_GNOME_40) {
     Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 }
 
-let settings;
-
 const PrefsWidget = GObject.registerClass({
     GTypeName: 'PrefsWidget',
     CssName: 'PrefsWidget',
@@ -56,24 +54,25 @@ const PrefsWidget = GObject.registerClass({
 }, class PrefsWidget extends Gtk.Box {
     _init(params = {}) {
         super._init(params);
+        this._settings = JSettings.settings();
 
-        let effect = settings.get_value('effect').deep_unpack();
+        let effect = this._settings.get_value('effect').deep_unpack();
 
         // set the main effect combobox value
         this._effect.set_active(effect);
-        this._shake_threshold.set_value(settings.get_value('shake-threshold').deep_unpack());
-        this._log_level.set_active(settings.get_value('log-level').deep_unpack());
-        this._use_system.set_active(settings.get_value('use-system').deep_unpack());
-        this._hide_original.set_active(settings.get_value('hide-original').deep_unpack());
-        this._growth_speed.set_value(settings.get_value('growth-speed').deep_unpack());
-        this._shrink_speed.set_value(settings.get_value('shrink-speed').deep_unpack());
-        this._fireworks_burst_speed.set_value(settings.get_value('fireworks-burst-speed').deep_unpack());
-        this._fireworks_spark_count.set_value(settings.get_value('fireworks-spark-count').deep_unpack());
-        this._fireworks_spark_trail.set_value(settings.get_value('fireworks-spark-trail').deep_unpack());
-        this._spotlight_size.set_value(settings.get_value('spotlight-size').deep_unpack());
-        this._spotlight_show_speed.set_value(settings.get_value('spotlight-show-speed').deep_unpack());
-        this._spotlight_hide_speed.set_value(settings.get_value('spotlight-hide-speed').deep_unpack());
-        this._trail_speed.set_value(settings.get_value('trail-speed').deep_unpack());
+        this._shake_threshold.set_value(this._settings.get_value('shake-threshold').deep_unpack());
+        this._log_level.set_active(this._settings.get_value('log-level').deep_unpack());
+        this._use_system.set_active(this._settings.get_value('use-system').deep_unpack());
+        this._hide_original.set_active(this._settings.get_value('hide-original').deep_unpack());
+        this._growth_speed.set_value(this._settings.get_value('growth-speed').deep_unpack());
+        this._shrink_speed.set_value(this._settings.get_value('shrink-speed').deep_unpack());
+        this._fireworks_burst_speed.set_value(this._settings.get_value('fireworks-burst-speed').deep_unpack());
+        this._fireworks_spark_count.set_value(this._settings.get_value('fireworks-spark-count').deep_unpack());
+        this._fireworks_spark_trail.set_value(this._settings.get_value('fireworks-spark-trail').deep_unpack());
+        this._spotlight_size.set_value(this._settings.get_value('spotlight-size').deep_unpack());
+        this._spotlight_show_speed.set_value(this._settings.get_value('spotlight-show-speed').deep_unpack());
+        this._spotlight_hide_speed.set_value(this._settings.get_value('spotlight-hide-speed').deep_unpack());
+        this._trail_speed.set_value(this._settings.get_value('trail-speed').deep_unpack());
 
         this._setActiveEffect(effect);
     }
@@ -85,26 +84,26 @@ const PrefsWidget = GObject.registerClass({
     _onEffectChanged(widget) {
         let effect = widget.get_active();
         // set the value in the settings
-        settings.set_int(this._getGSettingsKeyFromWidgetName(widget), effect);
+        this._settings.set_int(this._getGSettingsKeyFromWidgetName(widget), effect);
         this._setActiveEffect(effect)
     }
 
     _onLogLevelChanged(widget) {
         let level = widget.get_active();
-        settings.set_int(this._getGSettingsKeyFromWidgetName(widget), level);
+        this._settings.set_int(this._getGSettingsKeyFromWidgetName(widget), level);
         JLog.setLogLevel(level);
     }
 
     _onScaleFloatValueChanged(widget) {
-        settings.set_double(this._getGSettingsKeyFromWidgetName(widget), widget.get_value());
+        this._settings.set_double(this._getGSettingsKeyFromWidgetName(widget), widget.get_value());
     }
 
     _onScaleIntValueChanged(widget) {
-        settings.set_int(this._getGSettingsKeyFromWidgetName(widget), widget.get_value());
+        this._settings.set_int(this._getGSettingsKeyFromWidgetName(widget), widget.get_value());
     }
 
     _onSwitchStateSet(widget, state) {
-        settings.set_boolean(this._getGSettingsKeyFromWidgetName(widget), state);
+        this._settings.set_boolean(this._getGSettingsKeyFromWidgetName(widget), state);
         widget.set_active(state);
     }
 
@@ -127,7 +126,6 @@ const PrefsWidget = GObject.registerClass({
 
 // Like `extension.js` this is used for any one-time setup like translations.
 function init() {
-    settings = JSettings.settings();
 }
 
 // This function is called when the preferences window is first created to build and return a Gtk widget.


### PR DESCRIPTION
PR fixes 1, 3, and half of 4 from latest rejection:

1. `Tweener` is a deprecated module. Please remove it for the next version.
    You can use `ease()` instead (supported on 3.36 and higher). For example:

    ```js
    widget.ease({    
        x: newX,
        y: 10,
        opacity: 100,
        duration: 2000,
        mode: Clutter.AnimationMode.EASE_OUT_BOUNCE,
        onComplete: () => {
            log('Animation is finished');
        }
    });
    ```

    More about animation mode:
    https://gjs-docs.gnome.org/clutter10~10_api/clutter.animationmode

2. Don't create objects in global scope (line 130 prefs.js).
    Create gsettings object inside `PrefsWidget`.

3. What's the reason for disabling extension in init? (line 113 extension.js).
    You shouldn't need that.

4. enable and disable function shouldn't throw like that.
    Please remove those try catch block.

5. Where do you remove those timeouts you are adding in enable?
    https://gjs.guide/extensions/review-guidelines/review-guidelines.html#remove-main-loop-sources