### PR TITLE
GNOME 43 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Jiggle",
     "description": "Jiggle is a Gnome Shell extension that highlights the cursor position when the mouse is moved rapidly.",
     "url": "https://github.com/jeffchannell/jiggle",
-    "shell-version": [ "40", "41", "42" ],
+    "shell-version": [ "40", "41", "42", "43" ],
     "version": "9"
 }


### PR DESCRIPTION
Updated `metadata.json` to allow it to run within GNOME 43.

As far as I can tell, everything functions correctly; cursor jiggles as intended.