### PR TITLE
Support system-wide gschema

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -12,13 +12,19 @@ const Me = ExtensionUtils.getCurrentExtension();
  */
 function settings()
 {
-    let gschema = Gio.SettingsSchemaSource.new_from_directory(
-        Me.dir.get_child('schemas').get_path(),
-        Gio.SettingsSchemaSource.get_default(),
-        false
-    );
+    // first try developer friendly embedded schema
+    try {
+        let gschema = Gio.SettingsSchemaSource.new_from_directory(
+            Me.dir.get_child('schemas').get_path(),
+            Gio.SettingsSchemaSource.get_default(),
+            false
+        );
+        return new Gio.Settings({
+            settings_schema: gschema.lookup('org.gnome.shell.extensions.jiggle', true)
+        });
+    } catch (e) {
+        // now try system one below
+    }
 
-    return new Gio.Settings({
-        settings_schema: gschema.lookup('org.gnome.shell.extensions.jiggle', true)
-    });
+    return new Gio.Settings({schema_id: 'org.gnome.shell.extensions.jiggle'});
 }


### PR DESCRIPTION
When installing the extension system-wide, it currently fails to load producing the following error:

```
dec 02 21:43:08 x11sslf gnome-shell[2134]: JS ERROR: Extension jiggle@jeffchannell.com: GLib.FileError: Openen van bestand ‘/usr/share/gnome-shell/extensions/jiggle@jeffchannell.com/sc>
                                           settings@/usr/share/gnome-shell/extensions/jiggle@jeffchannell.com/settings.js:15:44
                                           enable@/usr/share/gnome-shell/extensions/jiggle@jeffchannell.com/extension.js:63:30
                                           _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:184:32
                                           loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:385:26
                                           _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:633:18
                                           collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:28:28
                                           _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:612:19
                                           _enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:639:18
                                           _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:659:14
                                           init@resource:///org/gnome/shell/ui/extensionSystem.js:57:14
                                           _initializeUI@resource:///org/gnome/shell/ui/main.js:309:22
                                           start@resource:///org/gnome/shell/ui/main.js:186:5
                                           @resource:///org/gnome/shell/ui/init.js:6:17
```

This PR resolves that issue by adding a fallback to the system-wide gschema if the schemas directory doesn't exist.